### PR TITLE
Update readme go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Mutation testing is also especially interesting for comparing automatically gene
 go-mutesting includes a binary which is go-getable.
 
 ```bash
-go get -t -v github.com/avito-tech/go-mutesting/...
+go install -v github.com/avito-tech/go-mutesting/...
 ```
 
 The binary's help can be invoked by executing the binary without arguments or with the `--help` argument.


### PR DESCRIPTION
Since 1.17 in go you cannot use go get for executables.