### PR TITLE
fix: set types.Config.Sizes to prevent nil pointer panic on Go 1.21+

### DIFF
--- a/internal/parser/parse.go
+++ b/internal/parser/parse.go
@@ -55,6 +55,9 @@ func ParseAndTypeCheckFile(file string, collectors []filter.NodeCollector) (*ast
 
 	var conf = loader.Config{
 		ParserMode: parser.AllErrors | parser.ParseComments,
+		TypeChecker: types.Config{
+			Sizes: types.SizesFor("gc", build.Default.GOARCH),
+		},
 	}
 
 	if buildPkg.ImportPath != "." {

--- a/internal/parser/parse.go
+++ b/internal/parser/parse.go
@@ -53,11 +53,13 @@ func ParseAndTypeCheckFile(file string, collectors []filter.NodeCollector) (*ast
 		return nil, nil, nil, nil, fmt.Errorf("Could not create build package of %q: %v", file, err)
 	}
 
+	typeConf := types.Config{}
+	if sz := types.SizesFor("gc", build.Default.GOARCH); sz != nil {
+		typeConf.Sizes = sz
+	}
 	var conf = loader.Config{
-		ParserMode: parser.AllErrors | parser.ParseComments,
-		TypeChecker: types.Config{
-			Sizes: types.SizesFor("gc", build.Default.GOARCH),
-		},
+		ParserMode:  parser.AllErrors | parser.ParseComments,
+		TypeChecker: typeConf,
 	}
 
 	if buildPkg.ImportPath != "." {


### PR DESCRIPTION
Go 1.21+ requires `types.Config.Sizes` to be set; without it, `go/types.(*StdSizes).Sizeof` dereferences a nil pointer and crashes go-mutesting immediately, which is the root cause described in #37 and reported again in #44.

Closes #37.