### PR TITLE
chore: replace archived golint with staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install-tools:
 	go install golang.org/x/tools/cmd/stringer
 
 	# linting
-	go install golang.org/x/lint/golint@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 	go install github.com/kisielk/errcheck@latest
 
 	# code coverage

--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -3,8 +3,9 @@
 if [ -z ${PKG+x} ]; then echo "PKG is not set"; exit 1; fi
 if [ -z ${ROOT_DIR+x} ]; then echo "ROOT_DIR is not set"; exit 1; fi
 
+# SA1019 (deprecated API) is suppressed until the go/loader -> go/packages migration is done.
 echo "staticcheck:"
-OUT=$(staticcheck $PKG/... 2>&1 | grep --invert-match -E "(/example)")
+OUT=$(staticcheck -checks=all,-SA1019 $PKG/... 2>&1 | grep --invert-match -E "(/example)")
 if [ -n "$OUT" ]; then echo "$OUT"; PROBLEM=1; fi
 
 if [ -n "$PROBLEM" ]; then exit 1; fi

--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -3,8 +3,8 @@
 if [ -z ${PKG+x} ]; then echo "PKG is not set"; exit 1; fi
 if [ -z ${ROOT_DIR+x} ]; then echo "ROOT_DIR is not set"; exit 1; fi
 
-echo "golint:"
-OUT=$(golint $PKG/... 2>&1 | grep --invert-match -E "(/example)")
+echo "staticcheck:"
+OUT=$(staticcheck $PKG/... 2>&1 | grep --invert-match -E "(/example)")
 if [ -n "$OUT" ]; then echo "$OUT"; PROBLEM=1; fi
 
 if [ -n "$PROBLEM" ]; then exit 1; fi


### PR DESCRIPTION
`golang.org/x/lint/golint` is archived and no longer maintained; `staticcheck` is the actively maintained replacement that understands modern Go and is updated alongside each toolchain release.