### PR TITLE
ci: add self-mutation-testing workflow and kill 8 surviving filter mutants

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,38 @@
+name: Mutation Testing
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build go-mutesting
+        run: go build -o /usr/local/bin/go-mutesting ./cmd/go-mutesting
+
+      - name: Run mutation testing
+        # Scoped to packages with isolated unit tests. cmd/ is excluded because
+        # its tests are integration tests that re-invoke the binary. internal/annotation
+        # is excluded until its build errors are resolved.
+        run: |
+          go-mutesting \
+            --exec-timeout 30 \
+            github.com/avito-tech/go-mutesting/mutator/arithmetic \
+            github.com/avito-tech/go-mutesting/mutator/branch \
+            github.com/avito-tech/go-mutesting/mutator/expression \
+            github.com/avito-tech/go-mutesting/mutator/loop \
+            github.com/avito-tech/go-mutesting/mutator/numbers \
+            github.com/avito-tech/go-mutesting/mutator/statement \
+            github.com/avito-tech/go-mutesting/internal/filter
+        # Informational only: do not fail the build on mutation score.
+        continue-on-error: true

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,9 +21,14 @@ jobs:
         run: go build -o /usr/local/bin/go-mutesting ./cmd/go-mutesting
 
       - name: Run mutation testing
-        # Scoped to packages with isolated unit tests. cmd/ is excluded because
-        # its tests are integration tests that re-invoke the binary. internal/annotation
-        # is excluded until its build errors are resolved.
+        # Scoped to packages with isolated unit tests.
+        # Excluded:
+        #   cmd/               - integration tests re-invoke the binary (would recurse)
+        #   internal/annotation - build errors prevent compilation
+        #   internal/importing  - relies on GOPATH/src layout; fails in module mode
+        #   internal/parser     - uses deprecated go/loader; excluded until migration
+        # The tool always exits 0 regardless of mutation score, so this step is
+        # informational. Check report.json for the full breakdown.
         run: |
           go-mutesting \
             --exec-timeout 30 \
@@ -34,5 +39,3 @@ jobs:
             github.com/avito-tech/go-mutesting/mutator/numbers \
             github.com/avito-tech/go-mutesting/mutator/statement \
             github.com/avito-tech/go-mutesting/internal/filter
-        # Informational only: do not fail the build on mutation score.
-        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# go-mutesting build output and run artifacts
+/go-mutesting
+report.json
+report.html
+*.go.new

--- a/internal/filter/skip_mutation_test.go
+++ b/internal/filter/skip_mutation_test.go
@@ -88,33 +88,26 @@ func TestSkipMutationForInitSlicesAndMaps(t *testing.T) {
 			expectedOperators: []string{"+", "*"},
 		},
 		{
-			// kills mutants that relax len(callExpr.Args) > 1 to >= 1, > 0, or true:
-			// with those mutants the 1-arg make(MySlice) enters the isIdent branch
-			// and panics on Args[1] access.
+			// make(MySlice) with one arg is syntactically valid for the parser even though
+			// the type-checker would reject it; it exercises the len(Args) > 1 guard.
 			name:              "do not skip mutation for single-arg make with type alias",
 			code:              `package main; type MySlice []int; var a = make(MySlice)`,
 			expectedLiterals:  []string{},
 			expectedOperators: []string{},
 		},
 		{
-			// kills mutants that remove or noop the else branch of the UnaryExpr case:
-			// without recursion into -(2+3), the "2", "3", and "+" inside are not collected.
 			name:              "skip mutation for unary negation of complex inner expression",
 			code:              `package main; var a = make([]int, 0, -(2+3))`,
 			expectedLiterals:  []string{"0", "2", "3"},
 			expectedOperators: []string{"+"},
 		},
 		{
-			// kills mutants that break or remove the collectForIgnoredNodes call inside the
-			// CallExpr case loop: with those mutants only the first arg (or nothing) is collected.
 			name:              "skip mutation for nested call with multiple int args",
 			code:              `package main; var a = make([]int, someFunc(2, 3))`,
 			expectedLiterals:  []string{"2", "3"},
 			expectedOperators: []string{},
 		},
 		{
-			// kills the mutant that replaces xLit.Kind == token.INT with true: that mutant
-			// treats float unary operands like int ones and adds their operator positions.
 			name:              "do not skip mutation for unary on float literals",
 			code:              `package main; var a = make([]float64, -1.5, +2.3)`,
 			expectedLiterals:  []string{},

--- a/internal/filter/skip_mutation_test.go
+++ b/internal/filter/skip_mutation_test.go
@@ -87,6 +87,39 @@ func TestSkipMutationForInitSlicesAndMaps(t *testing.T) {
 			expectedLiterals:  []string{"3", "2", "4"},
 			expectedOperators: []string{"+", "*"},
 		},
+		{
+			// kills mutants that relax len(callExpr.Args) > 1 to >= 1, > 0, or true:
+			// with those mutants the 1-arg make(MySlice) enters the isIdent branch
+			// and panics on Args[1] access.
+			name:              "do not skip mutation for single-arg make with type alias",
+			code:              `package main; type MySlice []int; var a = make(MySlice)`,
+			expectedLiterals:  []string{},
+			expectedOperators: []string{},
+		},
+		{
+			// kills mutants that remove or noop the else branch of the UnaryExpr case:
+			// without recursion into -(2+3), the "2", "3", and "+" inside are not collected.
+			name:              "skip mutation for unary negation of complex inner expression",
+			code:              `package main; var a = make([]int, 0, -(2+3))`,
+			expectedLiterals:  []string{"0", "2", "3"},
+			expectedOperators: []string{"+"},
+		},
+		{
+			// kills mutants that break or remove the collectForIgnoredNodes call inside the
+			// CallExpr case loop: with those mutants only the first arg (or nothing) is collected.
+			name:              "skip mutation for nested call with multiple int args",
+			code:              `package main; var a = make([]int, someFunc(2, 3))`,
+			expectedLiterals:  []string{"2", "3"},
+			expectedOperators: []string{},
+		},
+		{
+			// kills the mutant that replaces xLit.Kind == token.INT with true: that mutant
+			// treats float unary operands like int ones and adds their operator positions.
+			name:              "do not skip mutation for unary on float literals",
+			code:              `package main; var a = make([]float64, -1.5, +2.3)`,
+			expectedLiterals:  []string{},
+			expectedOperators: []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs go-mutesting on its own packages, and adds four new test cases to `internal/filter` that kill all 8 mutants that were left alive when we ran the tool against itself.