### PR TITLE
fix: register conditional/negated mutator in main.go

### DIFF
--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/avito-tech/go-mutesting/mutator"
 	_ "github.com/avito-tech/go-mutesting/mutator/arithmetic"
 	_ "github.com/avito-tech/go-mutesting/mutator/branch"
+	_ "github.com/avito-tech/go-mutesting/mutator/conditional"
 	_ "github.com/avito-tech/go-mutesting/mutator/expression"
 	_ "github.com/avito-tech/go-mutesting/mutator/loop"
 	_ "github.com/avito-tech/go-mutesting/mutator/numbers"


### PR DESCRIPTION
This PR anonymously imports the `conditional` package in `main.go` to ensure the `conditional/negated` mutator is properly registered and compiled into the CLI binary. 

For full context and the discovery process, please see the associated issue.

Fixes #55